### PR TITLE
Allow users to specify benchmark name to run single benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,5 +27,6 @@ jobs:
       - uses: jasonwilliams/criterion-compare-action@move_to_actions
         with:
           cwd: "subDirectory (optional)"
+          benchName: "example-bench-target" # Optional. Compare only this benchmark target
           token: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/main.js
+++ b/main.js
@@ -14,6 +14,11 @@ async function main() {
   if ((cwd = core.getInput("cwd"))) {
     options.cwd = cwd;
   }
+  
+  benchCmd = ["bench"];
+  if ((cargoBenchName = core.getInput("benchName"))) {
+    benchCmd = benchCmd.concat(["--bench", cargoBenchName]);
+  }
 
   core.debug("### Install Critcmp ###");
   await exec.exec("cargo", ["install", "critcmp"]);
@@ -21,7 +26,7 @@ async function main() {
   core.debug("### Benchmark starting ###");
   await exec.exec(
     "cargo",
-    ["bench", "--", "--save-baseline", "changes"],
+    benchCmd.concat(["--", "--save-baseline", "changes"]),
     options
   );
   core.debug("Changes benchmarked");
@@ -29,7 +34,7 @@ async function main() {
   core.debug("Checked out to master branch");
   await exec.exec(
     "cargo",
-    ["bench", "--", "--save-baseline", "master"],
+    benchCmd.concat(["--", "--save-baseline", "master"]),
     options
   );
   core.debug("Master benchmarked");


### PR DESCRIPTION
Thanks for the action!

I wanted to extend it slightly to allow users to specify only a certain bench target. This should allow a user to define `benchName` as an action option, which then gets passed down into the `cargo bench` command.