### PR TITLE
Bump node to minimal supported version

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -14,6 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Check code formatting
         run: npx prettier --check .

--- a/.github/workflows/pr-main.yml
+++ b/.github/workflows/pr-main.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Check if generated code is correct
-        uses: actions/setup-node@v3.6.0
+        uses: actions/setup-node@v4
         with:
           node-version: "20"
       - run: mv dist/index.js dist/index.js.new

--- a/.github/workflows/pr-main.yml
+++ b/.github/workflows/pr-main.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Check if generated code is correct
         uses: actions/setup-node@v3.6.0
         with:
-          node-version: "16"
+          node-version: "20"
       - run: mv dist/index.js dist/index.js.new
       - run: npm ci
       - run: npm run build


### PR DESCRIPTION
This action previously requested node-16 which is unsupported and was
automatically bumped to the minimal supported version node-20. This
triggered a warning for users:

```
The following actions use a deprecated Node.js version and will be forced to run on node20: boa-dev/criterion-compare-action@v3.  For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
```